### PR TITLE
[CIR] Added support for `__builtin_ia32_pshufd`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -1003,8 +1003,35 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned BuiltinID,
   case X86::BI__builtin_ia32_vpermilpd256:
   case X86::BI__builtin_ia32_vpermilps256:
   case X86::BI__builtin_ia32_vpermilpd512:
-  case X86::BI__builtin_ia32_vpermilps512:
-    llvm_unreachable("pshufd NYI");
+  case X86::BI__builtin_ia32_vpermilps512: {
+    uint32_t imm = getIntValueFromConstOp(Ops[1]);
+    auto vecTy = cast<cir::VectorType>(Ops[0].getType());
+    unsigned numElts = vecTy.getSize();
+    auto eltTy = vecTy.getElementType();
+    unsigned eltBitWidth = 0;
+
+    if (auto intTy = mlir::dyn_cast<cir::IntType>(eltTy)) {
+      eltBitWidth = intTy.getWidth();
+    } else if (auto floatTy = mlir::dyn_cast<cir::SingleType>(eltTy)) {
+      eltBitWidth = 32;
+    } else if (auto doubleTy = mlir::dyn_cast<cir::DoubleType>(eltTy)) {
+      eltBitWidth = 64;
+    }
+
+    unsigned vecBitWidth = numElts + eltBitWidth;
+    unsigned numLanes = vecBitWidth / 128;
+    unsigned numLaneElts = numElts / numLanes;
+
+    imm = (imm & 0xff) * 0x01010101;
+    llvm::SmallVector<int64_t, 16> indices;
+    for (unsigned l = 0; l != numElts; l += numLaneElts) {
+      for (unsigned i = 0; i != numLanes; ++i) {
+        indices.push_back((imm % numLaneElts) + l);
+        imm /= numLaneElts;
+      }
+    }
+    return builder.createVecShuffle(getLoc(E->getExprLoc()), Ops[0], indices);
+  }
   case X86::BI__builtin_ia32_shufpd:
   case X86::BI__builtin_ia32_shufpd256:
   case X86::BI__builtin_ia32_shufpd512:

--- a/clang/test/CIR/CodeGen/builtin-x86-pshufd.cpp
+++ b/clang/test/CIR/CodeGen/builtin-x86-pshufd.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+// Test that __builtin_ia32_pshufd generates correct CIR vec.shuffle operations
+// This verifies the fix for SIMD intrinsic support that was previously NYI
+
+typedef int __v4si __attribute__((__vector_size__(16)));
+typedef __v4si __m128i;
+
+// CHECK-LABEL: @_Z11test_pshufdv
+void test_pshufd() {
+    __m128i vec = {1, 2, 3, 4};
+    // CHECK: cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<!s32i x 4>) [#cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<0> : !s32i, #cir.int<1> : !s32i] : !cir.vector<!s32i x 4>
+    __m128i result = __builtin_ia32_pshufd(vec, 0x4E);
+}
+
+// CHECK-LABEL: @_Z19test_different_maskv  
+void test_different_mask() {
+    __m128i vec = {10, 20, 30, 40};
+    // Test different immediate value: 0x1B = 00011011 = [3,2,1,0] reversed
+    // CHECK: cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<!s32i x 4>) [#cir.int<3> : !s32i, #cir.int<2> : !s32i, #cir.int<1> : !s32i, #cir.int<0> : !s32i] : !cir.vector<!s32i x 4>
+    __m128i result = __builtin_ia32_pshufd(vec, 0x1B);
+}
+
+// CHECK-LABEL: @_Z19test_stb_image_casev
+void test_stb_image_case() {
+    __m128i p0 = {1, 2, 3, 4};
+    
+    // This reproduces the exact pattern from stb_image.h:2685 that was failing:
+    // _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p0, 0x4e));
+    // Which expands to: __builtin_ia32_pshufd(p0, 0x4e)
+    // CHECK: cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<!s32i x 4>) [#cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<0> : !s32i, #cir.int<1> : !s32i] : !cir.vector<!s32i x 4>
+    __m128i out_vec = __builtin_ia32_pshufd(p0, 0x4e);
+}


### PR DESCRIPTION
### Summary

This PR implements support for the `__builtin_ia32_pshufd` SIMD intrinics in ClangIR

## Issues
The `__builtin_ia32_pshufd` intrinsic (used by `_mm_shuffle_epi32`) was hitting an `"NYI"` error, preventing compilation of code that uses common SIMD operations.